### PR TITLE
updates to oss repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -4,7 +4,7 @@ Describe the big picture of your changes here to communicate to the maintainers 
 
 ## Types of changes
 
-What types of changes does your code introduce to the Vonage for Visual Studio Code extension?
+What types of changes does your code introduce?
 _Put an `x` in the boxes that apply_
 
 - [ ] Bugfix (non-breaking change which fixes an issue)
@@ -14,7 +14,7 @@ _Put an `x` in the boxes that apply_
 
 ## Checklist
 
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+_Put an `x` in the boxes that apply.This is simply a reminder of what we are going to look for before merging your code._
 
 - [ ] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) doc
 - [ ] Lint and unit tests pass locally with my changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,13 +116,17 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-<https://www.contributor-covenant.org/faq>. Translations are available at
-<https://www.contributor-covenant.org/translations>.
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,6 @@ Here are a few types of contributions that we would be interested in hearing abo
     it.
     * If its a trivial change, go ahead and send a Pull Request with the changes you have in mind
     * If not, open a Github Issue to discuss the idea first.
-* Snippets
-  * To add snippets:
-    * Add a directory in the `snippets` folder with the name of the language.
-    * Add one or more files in the language directory with snippets.
-    * Update the `package.json` to include the snippets you added.
 
 We also welcome anyone to work on any existing issues with the `👋🏽 good first issue` tag.
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,29 @@
 
 A repository template for open-source demos, guides and sample apps. Description here.
 
+## Getting an API Key
+
+🔑 To access the Deepgram API you will need a [free Deepgram API Key](https://console.deepgram.com/signup?jump=keys).
+
+## Documentation
+
+You can learn more about the Deepgram API at [developers.deepgram.com](https://developers.deepgram.com/docs).
+
 ## Development and Contributing
 
 Interested in contributing? We ❤️ pull requests!
 
 To make sure our community is safe for all, be sure to review and agree to our
-[Code of Conduct](./CODE_OF_CONDUCT.md). Then see the
-[Contribution](./CONTRIBUTING.md) guidelines for more information.
+[Code of Conduct](./.github/CODE_OF_CONDUCT.md). Then see the
+[Contribution](./.github/CONTRIBUTING.md) guidelines for more information.
 
 ## Getting Help
 
 We love to hear from you so if you have questions, comments or find a bug in the
 project, let us know! You can either:
 
-- [Open an issue](https://github.com/deepgram/[reponame]/issues/new) on this repository
-- Tweet at us! We're [@DeepgramDevs on Twitter](https://twitter.com/DeepgramDevs)
+- [Open an issue in this repository](https://github.com/deepgram/[reponame]/issues/new)
+- [Join the Deepgram Github Discussions Community](https://github.com/orgs/deepgram/discussions)
+- [Join the Deepgram Discord Community](https://discord.gg/xWRaCDBtW4)
 
-## Further Reading
-
-Check out the Developer Documentation at [https://developers.deepgram.com/](https://developers.deepgram.com/)
+[license]: LICENSE.txt


### PR DESCRIPTION
Updates repo templates with:

- add sign up for a free key in readme ✅
- Update Code of conduct ✅
- https://www.contributor-covenant.org/version/2/0/code_of_conduct/
- better (shorter!) template for issues and PRs ✅
- Update contributor guidelines: ✅
- update repo descriptions & readmes so it's clear what
these templates are used for ✅
